### PR TITLE
IN-1141 checking if table throughputs was provided

### DIFF
--- a/dynamodb/query_builder.go
+++ b/dynamodb/query_builder.go
@@ -169,7 +169,9 @@ func (q *Query) AddUpdateRequestTable(description TableDescriptionT) {
 	b := q.buffer
 
 	b["TableName"] = description.TableName
-	b["ProvisionedThroughput"] = q.capacityUnitsMsi(description.ProvisionedThroughput)
+	if tableThroughput := q.capacityUnitsMsi(description.ProvisionedThroughput); len(tableThroughput) > 0 {
+		b["ProvisionedThroughput"] = tableThroughput
+	}
 
 	globalSecondaryIndexes := []interface{}{}
 


### PR DESCRIPTION
When ProvisionedThroughput is set to an empty hash, Dynamodb
will complain that the capacity units were not set.
